### PR TITLE
Fix prevent submit on back button

### DIFF
--- a/router/routes.js
+++ b/router/routes.js
@@ -26,6 +26,7 @@ router.get("/formulario/:id", (req, res) => {
             if (err) {
               throw err;
             } else {
+              nocache(res)
               res.render("formulario", { datos: results[0], cod: resbd[0] });
             }
           }
@@ -34,4 +35,11 @@ router.get("/formulario/:id", (req, res) => {
     }
   );
 });
+
+function nocache(res) {
+  res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
+  res.header('Expires', '-1');
+  res.header('Pragma', 'no-cache');
+}
+
 module.exports = router;


### PR DESCRIPTION
Por alguna razón, cuando le das atrás, el formulario se envia solo sin necesidad de dar click en "Agregar cotizador", buscando un poco encontre esto:

https://stackoverflow.com/questions/37511043/how-to-stop-re-submitting-a-form-after-clicking-back-button

Ahi menciona varias opciones, la que implemente fue la de deshabilitar el cache para que el navegador se vea obligado a cargar la página de nuevo